### PR TITLE
git rebase for fixing bug of compression for support chatglm,chatglm2 when use --load-8bit

### DIFF
--- a/fastchat/data/get_stats.py
+++ b/fastchat/data/get_stats.py
@@ -34,15 +34,6 @@ def tokenize_dataset(content):
     return processed
 
 
-def compute_avg_turns(content):
-    res_lens = []
-
-    for c in content:
-        turns.append(len(c["conversations"]) // 2)
-
-    return np.mean(turns)
-
-
 def compute_stats(content):
     total_len = 0
     turns = []

--- a/fastchat/data/get_stats.py
+++ b/fastchat/data/get_stats.py
@@ -5,14 +5,37 @@ Usage: python3 -m fastchat.data.get_stats --in sharegpt.json
 """
 
 import argparse
+from concurrent.futures import ProcessPoolExecutor
 import json
 
-from transformers import AutoTokenizer, AutoModelForCausalLM
 import numpy as np
+from tqdm import tqdm
+from transformers import AutoTokenizer, AutoModelForCausalLM
+
+K = 1e3
+M = 1e6
+
+
+def tokenize_one_sample(c):
+    for i in range(len(c["conversations"])):
+        v = c["conversations"][i]["value"]
+        c["conversations"][i]["value"] = tokenizer.tokenize(v)
+    return c
+
+
+def tokenize_dataset(content):
+    processed = []
+    with ProcessPoolExecutor() as executor:
+        for result in tqdm(
+            executor.map(tokenize_one_sample, content), total=len(content)
+        ):
+            processed.append(result)
+
+    return processed
 
 
 def compute_avg_turns(content):
-    turns = []
+    res_lens = []
 
     for c in content:
         turns.append(len(c["conversations"]) // 2)
@@ -20,29 +43,42 @@ def compute_avg_turns(content):
     return np.mean(turns)
 
 
-def compute_avg_response_length(content, tokenizer):
+def compute_stats(content):
+    total_len = 0
+    turns = []
+    prompt_lens = []
     res_lens = []
 
     for c in content:
+        turns.append(len(c["conversations"]) // 2)
         for i in range(len(c["conversations"]) // 2):
-            v = c["conversations"][i * 2 + 1]["value"]
-            res_lens.append(len(tokenizer.tokenize(v)))
+            p = c["conversations"][i * 2]["value"]
+            r = c["conversations"][i * 2 + 1]["value"]
 
-    return np.mean(res_lens)
+            turn_len = len(p) + len(r)
+            total_len += turn_len
+            prompt_lens.append(len(p))
+            res_lens.append(len(r))
+
+    return total_len, np.mean(turns), np.mean(prompt_lens), np.mean(res_lens)
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--in-file", type=str)
-    parser.add_argument("--model-path", type=str)
+    parser.add_argument(
+        "--model-name-or-path", type=str, default="meta-llama/Llama-2-7b-chat-hf"
+    )
     args = parser.parse_args()
 
-    tokenizer = AutoTokenizer.from_pretrained(args.model_path, use_fast=False)
     content = json.load(open(args.in_file, "r"))
+    tokenizer = AutoTokenizer.from_pretrained(args.model_name_or_path, use_fast=False)
+    content = tokenize_dataset(content)
 
-    avg_turns = compute_avg_turns(content)
-    avg_res_len = compute_avg_response_length(content, tokenizer)
+    total_len, avg_turn, avg_prompt_len, avg_res_len = compute_stats(content)
 
-    print(f"#sequence: {len(content)}")
-    print(f"avg. turns: {avg_turns:.2f}")
+    print(f"#sequence: {len(content)/K:.2f} K")
+    print(f"#tokens: {total_len/M:.2f} M")
+    print(f"avg. turns: {avg_turn:.2f}")
+    print(f"avg. prompt length: {avg_prompt_len:.2f}")
     print(f"avg. response length: {avg_res_len:.2f}")

--- a/fastchat/data/prepare_all.py
+++ b/fastchat/data/prepare_all.py
@@ -10,17 +10,24 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--prefix", type=str, default="~/datasets/sharegpt_20230521")
     parser.add_argument(
-        "--model-name-or-path", type=str, default="~/model_weights/llama-7b"
+        "--model-name-or-path", type=str, default="meta-llama/Llama-2-7b-chat-hf"
     )
+    parser.add_argument("--seq-len", type=int, default=4096)
     args = parser.parse_args()
 
-    prefix = args.prefix
+    in_prefix = args.prefix
     model_path = args.model_name_or_path
+    seq_len = args.seq_len
+    prefix = (
+        f"{in_prefix}_{seq_len}".replace("4096", "4k")
+        .replace("8192", "8k")
+        .replace("16384", "16k")
+    )
 
     cmd_list = [
-        f"python3 -m fastchat.data.clean_sharegpt --in {prefix}_html.json --out {prefix}_clean.json",
+        f"python3 -m fastchat.data.clean_sharegpt --in {in_prefix}_html.json --out {prefix}_clean.json",
         f"python3 -m fastchat.data.optional_clean --in {prefix}_clean.json --out {prefix}_clean_lang.json --skip-lang ko",
-        f"python3 -m fastchat.data.split_long_conversation --in {prefix}_clean_lang.json --out {prefix}_clean_lang_split.json --model-name {model_path}",
+        f"python3 -m fastchat.data.split_long_conversation --in {prefix}_clean_lang.json --out {prefix}_clean_lang_split.json --model-name {model_path} --max-length {seq_len}",
         f"python3 -m fastchat.data.filter_wrong_format --in {prefix}_clean_lang_split.json --out {prefix}_clean_lang_split.json",
         f"python3 -m fastchat.data.split_train_test --in {prefix}_clean_lang_split.json --ratio 0.99",
         f"python3 -m fastchat.data.hardcoded_questions",

--- a/fastchat/model/model_registry.py
+++ b/fastchat/model/model_registry.py
@@ -81,22 +81,16 @@ register_model_info(
     "an instruction-following LLM using evol-instruct by Microsoft",
 )
 register_model_info(
+    ["mpt-7b-chat", "mpt-30b-chat"],
+    "MPT-Chat",
+    "https://www.mosaicml.com/blog/mpt-30b",
+    "a chatbot fine-tuned from MPT by MosaicML",
+)
+register_model_info(
     ["guanaco-33b", "guanaco-65b"],
     "Guanaco",
     "https://github.com/artidoro/qlora",
     "a model fine-tuned with QLoRA by UW",
-)
-register_model_info(
-    ["mpt-7b-chat"],
-    "MPT-Chat",
-    "https://www.mosaicml.com/blog/mpt-7b",
-    "a chatbot fine-tuned from MPT-7B by MosaicML",
-)
-register_model_info(
-    ["mpt-30b-chat"],
-    "MPT-Chat",
-    "https://www.mosaicml.com/blog/mpt-30b",
-    "a chatbot fine-tuned from MPT-30B by MosaicML",
 )
 register_model_info(
     ["gpt4all-13b-snoozy"],
@@ -117,16 +111,16 @@ register_model_info(
     "an RNN with transformer-level LLM performance",
 )
 register_model_info(
-    ["alpaca-13b"],
-    "Alpaca",
-    "https://crfm.stanford.edu/2023/03/13/alpaca.html",
-    "a model fine-tuned from LLaMA on instruction-following demonstrations by Stanford",
-)
-register_model_info(
     ["chatglm-6b", "chatglm2-6b"],
     "ChatGLM",
     "https://chatglm.cn/blog",
     "an open bilingual dialogue language model by Tsinghua University",
+)
+register_model_info(
+    ["alpaca-13b"],
+    "Alpaca",
+    "https://crfm.stanford.edu/2023/03/13/alpaca.html",
+    "a model fine-tuned from LLaMA on instruction-following demonstrations by Stanford",
 )
 register_model_info(
     ["oasst-pythia-12b"],

--- a/fastchat/serve/controller.py
+++ b/fastchat/serve/controller.py
@@ -199,7 +199,7 @@ class Controller:
         for worker_name in to_delete:
             self.remove_worker(worker_name)
 
-    def handle_no_worker(params):
+    def handle_no_worker(self, params):
         logger.info(f"no worker: {params['model']}")
         ret = {
             "text": SERVER_ERROR_MSG,
@@ -207,7 +207,7 @@ class Controller:
         }
         return json.dumps(ret).encode() + b"\0"
 
-    def handle_worker_timeout(worker_address):
+    def handle_worker_timeout(self, worker_address):
         logger.info(f"worker timeout: {worker_address}")
         ret = {
             "text": SERVER_ERROR_MSG,
@@ -229,8 +229,9 @@ class Controller:
                 speed += worker_status["speed"]
                 queue_length += worker_status["queue_length"]
 
+        model_names = sorted(list(model_names))
         return {
-            "model_names": list(model_names),
+            "model_names": model_names,
             "speed": speed,
             "queue_length": queue_length,
         }

--- a/fastchat/serve/gradio_block_arena_anony.py
+++ b/fastchat/serve/gradio_block_arena_anony.py
@@ -161,31 +161,37 @@ def share_click(state0, state1, model_selector0, model_selector1, request: gr.Re
 
 
 SAMPLING_WEIGHTS = {
+    # tier 0
     "gpt-4": 1.5,
     "gpt-3.5-turbo": 1.5,
     "claude-2": 1.5,
     "claude-instant-1": 1.5,
-    "palm-2": 1.5,
+    "llama-2-13b-chat": 1.5,
     "vicuna-33b": 1.5,
     "vicuna-13b": 1.5,
-    "wizardlm-13b": 1.5,
-    "guanaco-33b": 1.5,
-    "koala-13b": 1.2,
-    "vicuna-7b": 1.2,
-    "mpt-7b-chat": 1.2,
-    "mpt-30b-chat": 1.2,
-    "gpt4all-13b-snoozy": 1.2,
-    "oasst-pythia-12b": 1.2,
-    "RWKV-4-Raven-14B": 1.2,
-    "fastchat-t5-3b": 0.9,
-    "alpaca-13b": 0.9,
-    "chatglm-6b": 0.8,
+    "mpt-30b-chat": 1.5,
+    # tier 1
+    "palm-2": 1.0,
+    "wizardlm-13b": 1.0,
+    "guanaco-33b": 1.0,
+    "vicuna-7b": 1.0,
+    "llama-2-7b-chat": 1.0,
+    # tier 2
+    "mpt-7b-chat": 0.5,
+    "oasst-pythia-12b": 0.5,
+    "RWKV-4-Raven-14B": 0.5,
+    "fastchat-t5-3b": 0.5,
+    "alpaca-13b": 0.5,
+    "chatglm-6b": 0.5,
+    # deprecated
+    "gpt4all-13b-snoozy": 1.0,
+    "koala-13b": 1.0,
     "stablelm-tuned-alpha-7b": 0.1,
     "dolly-v2-12b": 0.1,
     "llama-13b": 0.1,
 }
 
-SAMPLING_BOOST_MODELS = []
+SAMPLING_BOOST_MODELS = ["llama-2-13b-chat", "llama-2-7b-chat", "claude-2"]
 
 model_pairs = []
 model_pairs_weights = []
@@ -214,7 +220,7 @@ def add_text(
                     b = models[j]
                     w = SAMPLING_WEIGHTS.get(a, 1.0) * SAMPLING_WEIGHTS.get(b, 1.0)
                     if a in SAMPLING_BOOST_MODELS or b in SAMPLING_BOOST_MODELS:
-                        w *= 5
+                        w *= 10
                     model_pairs.append((a, b))
                     model_pairs_weights.append(w)
 

--- a/fastchat/serve/gradio_block_arena_named.py
+++ b/fastchat/serve/gradio_block_arena_named.py
@@ -50,7 +50,7 @@ def load_demo_side_by_side_named(models, url_params):
 
     model_left = models[0] if len(models) > 0 else ""
     if len(models) > 1:
-        weights = ([8, 4, 2, 1] + [1] * 32)[: len(models) - 1]
+        weights = ([8] * 4 + [4] * 8 + [1] * 32)[: len(models) - 1]
         weights = weights / np.sum(weights)
         model_right = np.random.choice(models[1:], p=weights)
     else:

--- a/fastchat/serve/monitor/basic_stats.py
+++ b/fastchat/serve/monitor/basic_stats.py
@@ -12,16 +12,18 @@ import plotly.graph_objects as go
 from tqdm import tqdm
 
 
+NUM_SERVERS = 14
+
+
 def get_log_files(max_num_files=None):
     dates = []
     for month in range(4, 8):
         for day in range(1, 33):
             dates.append(f"2023-{month:02d}-{day:02d}")
 
-    num_servers = 12
     filenames = []
     for d in dates:
-        for i in range(num_servers):
+        for i in range(NUM_SERVERS):
             name = os.path.expanduser(f"~/fastchat_logs/server{i}/{d}-conv.json")
             if os.path.exists(name):
                 filenames.append(name)

--- a/fastchat/serve/monitor/clean_battle_data.py
+++ b/fastchat/serve/monitor/clean_battle_data.py
@@ -13,7 +13,7 @@ import time
 
 from tqdm import tqdm
 
-from fastchat.serve.monitor.basic_stats import get_log_files
+from fastchat.serve.monitor.basic_stats import get_log_files, NUM_SERVERS
 from fastchat.utils import detect_language
 
 
@@ -47,10 +47,9 @@ def get_log_files(max_num_files=None):
         for day in range(1, 32):
             dates.append(f"2023-{month:02d}-{day:02d}")
 
-    num_servers = 12
     filenames = []
     for d in dates:
-        for i in range(num_servers):
+        for i in range(NUM_SERVERS):
             name = os.path.expanduser(f"~/fastchat_logs/server{i}/{d}-conv.json")
             if os.path.exists(name):
                 filenames.append(name)

--- a/fastchat/serve/monitor/elo_analysis.py
+++ b/fastchat/serve/monitor/elo_analysis.py
@@ -125,8 +125,8 @@ def visualize_pairwise_win_fraction(battles, model_order):
         row_beats_col,
         color_continuous_scale="RdBu",
         text_auto=".2f",
-        height=600,
-        width=600,
+        height=700,
+        width=700,
     )
     fig.update_layout(
         xaxis_title="Model B",
@@ -150,8 +150,8 @@ def visualize_battle_count(battles, model_order):
     fig = px.imshow(
         battle_counts.loc[model_order, model_order],
         text_auto=True,
-        height=600,
-        width=600,
+        height=700,
+        width=700,
     )
     fig.update_layout(
         xaxis_title="Model B",
@@ -171,8 +171,8 @@ def visualize_average_win_rate(battles):
     fig = px.bar(
         row_beats_col_freq.mean(axis=1).sort_values(ascending=False),
         text_auto=".2f",
-        height=400,
-        width=600,
+        height=500,
+        width=700,
     )
     fig.update_layout(
         yaxis_title="Average Win Rate", xaxis_title="Model", showlegend=False
@@ -202,8 +202,8 @@ def visualize_bootstrap_elo_rating(df):
         error_y="error_y",
         error_y_minus="error_y_minus",
         text="rating_rounded",
-        height=400,
-        width=600,
+        height=500,
+        width=700,
     )
     fig.update_layout(xaxis_title="Model", yaxis_title="Rating")
     return fig

--- a/fastchat/serve/monitor/inspect_conv.py
+++ b/fastchat/serve/monitor/inspect_conv.py
@@ -16,7 +16,7 @@ def get_log_files(max_num_files=None):
         for day in range(1, 32):
             dates.append(f"2023-{month:02d}-{day:02d}")
 
-    num_servers = 12
+    num_servers = 14
     filenames = []
     for d in dates:
         for i in range(num_servers):

--- a/fastchat/train/train_lora.py
+++ b/fastchat/train/train_lora.py
@@ -31,13 +31,25 @@ import torch
 from fastchat.train.train import (
     DataArguments,
     ModelArguments,
-    TrainingArguments,
     make_supervised_data_module,
 )
 
 from fastchat.train.llama_flash_attn_monkey_patch import (
     replace_llama_attn_with_flash_attn,
 )
+
+
+@dataclass
+class TrainingArguments(transformers.TrainingArguments):
+    cache_dir: Optional[str] = field(default=None)
+    optim: str = field(default="adamw_torch")
+    model_max_length: int = field(
+        default=512,
+        metadata={
+            "help": "Maximum sequence length. Sequences will be right padded (and possibly truncated)."
+        },
+    )
+    flash_attn: bool = False
 
 
 @dataclass
@@ -100,7 +112,7 @@ def train():
         lora_args,
     ) = parser.parse_args_into_dataclasses()
 
-    if model_args.flash_attn:
+    if training_args.flash_attn:
         replace_llama_attn_with_flash_attn()
 
     device_map = None

--- a/scripts/test_readme_train.sh
+++ b/scripts/test_readme_train.sh
@@ -1,22 +1,24 @@
-torchrun --nproc_per_node=4 --master_port=20001 fastchat/train/train.py \
+torchrun --nproc_per_node=4 --master_port=20001 fastchat/train/train_mem.py \
     --model_name_or_path ~/model_weights/llama-7b  \
-    --data_path ~/datasets/sampled.json \
-    --fp16 True \
+    --data_path data/dummy_conversation.json \
+    --bf16 True \
     --output_dir output_vicuna \
     --num_train_epochs 3 \
     --per_device_train_batch_size 2 \
     --per_device_eval_batch_size 2 \
-    --gradient_accumulation_steps 1 \
-    --evaluation_strategy "steps" \
-    --eval_steps 2 \
+    --gradient_accumulation_steps 16 \
+    --evaluation_strategy "no" \
     --save_strategy "steps" \
     --save_steps 1200 \
+    --save_total_limit 10 \
     --learning_rate 2e-5 \
     --weight_decay 0. \
     --warmup_ratio 0.03 \
     --lr_scheduler_type "cosine" \
     --logging_steps 1 \
-    --tf32 False \
+    --fsdp "full_shard auto_wrap" \
+    --fsdp_transformer_layer_cls_to_wrap 'LlamaDecoderLayer' \
+    --tf32 True \
     --model_max_length 2048 \
     --gradient_checkpointing True \
     --lazy_preprocess True


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

There are some problems in compression.py when we use `--load-8bit`:
1. `use_fast=True`` is not supported for some models when calling AutoTokenizer.from_pretrained.
2. Some models are loaded by AutoModel but not AutoModelForCausalLM, such as chatglm, chatglm2
3. We don't necessarily need to download the model' repo again if there is a cache. So check the default huggingface cache first,  and if there is no cache, call snapshot_download then.

## Related issue number (if applicable)
 #1789

## Checks

- [ ] I've run `format.sh` to lint the changes in this PR. --> I can't install black for the root problem.
- [x] I've included any doc changes needed. --> There is no doc need to change.
- [x] I've made sure the relevant tests are passing (if applicable). -->Yes, test on chatglm-6b
